### PR TITLE
Argon2: avoid loading multiple wasm modules on first initialisation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "openpgp",
+  "name": "@protontech/openpgp",
   "version": "5.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "openpgp",
+      "name": "@protontech/openpgp",
       "version": "5.9.0",
       "license": "LGPL-3.0+",
       "dependencies": {
@@ -24,7 +24,7 @@
         "@rollup/plugin-replace": "^2.3.2",
         "@rollup/plugin-wasm": "^6.1.2",
         "@types/chai": "^4.2.14",
-        "argon2id": "^1.0.0",
+        "argon2id": "^1.0.1",
         "benchmark": "^2.1.4",
         "bn.js": "^4.11.8",
         "chai": "^4.3.6",
@@ -986,9 +986,9 @@
       "dev": true
     },
     "node_modules/argon2id": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/argon2id/-/argon2id-1.0.0.tgz",
-      "integrity": "sha512-Z4TqH1xUnm2bq8b3WR5eQ37VPzpuJxezhlsMDXFJtEVmhJW5KWkEGzqILibsm9Nii6OGKsrLWVUczZePz3ZgzA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/argon2id/-/argon2id-1.0.1.tgz",
+      "integrity": "sha512-rsiD3lX+0L0CsiZARp3bf9EGxprtuWAT7PpiJd+Fk53URV0/USOQkBIP1dLTV8t6aui0ECbymQ9W9YCcTd6XgA==",
       "dev": true
     },
     "node_modules/argparse": {
@@ -8278,9 +8278,9 @@
       "dev": true
     },
     "argon2id": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/argon2id/-/argon2id-1.0.0.tgz",
-      "integrity": "sha512-Z4TqH1xUnm2bq8b3WR5eQ37VPzpuJxezhlsMDXFJtEVmhJW5KWkEGzqILibsm9Nii6OGKsrLWVUczZePz3ZgzA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/argon2id/-/argon2id-1.0.1.tgz",
+      "integrity": "sha512-rsiD3lX+0L0CsiZARp3bf9EGxprtuWAT7PpiJd+Fk53URV0/USOQkBIP1dLTV8t6aui0ECbymQ9W9YCcTd6XgA==",
       "dev": true
     },
     "argparse": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@rollup/plugin-replace": "^2.3.2",
     "@rollup/plugin-wasm": "^6.1.2",
     "@types/chai": "^4.2.14",
-    "argon2id": "^1.0.0",
+    "argon2id": "^1.0.1",
     "benchmark": "^2.1.4",
     "bn.js": "^4.11.8",
     "chai": "^4.3.6",

--- a/src/type/s2k/argon2.js
+++ b/src/type/s2k/argon2.js
@@ -91,10 +91,12 @@ class Argon2S2K {
     const decodedM = 2 << (this.encodedM - 1);
 
     try {
-      if (!argon2Promise) { // first load
-        loadArgonWasmModule = loadArgonWasmModule || (await import('argon2id')).default;
-        argon2Promise = loadArgonWasmModule();
-      }
+      // on first load, the argon2 lib is imported and the WASM module is initialized.
+      // the two steps need to be atomic to avoid race conditions causing multiple wasm modules
+      // to be loaded when `argon2Promise` is not initialized.
+      loadArgonWasmModule = loadArgonWasmModule || (await import('argon2id')).default;
+      argon2Promise = argon2Promise || loadArgonWasmModule();
+
       // important to keep local ref to argon2 in case the module is reloaded by another instance
       const argon2 = await argon2Promise;
 

--- a/src/type/s2k/argon2.js
+++ b/src/type/s2k/argon2.js
@@ -93,7 +93,7 @@ class Argon2S2K {
     try {
       // on first load, the argon2 lib is imported and the WASM module is initialized.
       // the two steps need to be atomic to avoid race conditions causing multiple wasm modules
-      // to be loaded when `argon2Promise` is not initialized.
+      // being loaded when `argon2Promise` is not initialized.
       loadArgonWasmModule = loadArgonWasmModule || (await import('argon2id')).default;
       argon2Promise = argon2Promise || loadArgonWasmModule();
 
@@ -116,6 +116,7 @@ class Argon2S2K {
       if (decodedM > ARGON2_WASM_MEMORY_THRESHOLD_RELOAD) {
         // it will be awaited if needed at the next `produceKey` invocation
         argon2Promise = loadArgonWasmModule();
+        argon2Promise.catch(() => {});
       }
       return hash;
     } catch (e) {


### PR DESCRIPTION
Follow up #5 :
Concurrent calls to `Argon2S2K.produceKey` prior to the `argon2Promise` being initialised could result in multiple Wasm modules being loaded, leading to performance overhead.
This scenario could be triggered during e.g. key (incl. subkey) decryption.

Further, due to a separate race-condition within the argon2id lib (see https://github.com/openpgpjs/argon2id/commit/364736a0e9acbc07157ab2f7783dd1a5dba63e2d), in the same scenario argon2 could fail to run on platforms without SIMD support (e.g. Safari 13).