### PR TITLE
[v6] Temporarily add `config.ignoreSEIPDv2FeatureFlag` for compatibility

### DIFF
--- a/src/config/config.js
+++ b/src/config/config.js
@@ -51,6 +51,14 @@ export default {
    */
   aeadProtect: false,
   /**
+   * Whether to disable encrypton using SEIPDv2 even if the encryption keys include the SEIPDv2 feature flag.
+   * If true, SEIPDv1 (i.e. no AEAD) packets are always used instead.
+   * SEIPDv2 is a more secure and faster choice, but it is not necessarily compatible with other libs and our mobile apps.
+   * @memberof module:config
+   * @property {Boolean} ignoreSEIPDv2FeatureFlag
+   */
+  ignoreSEIPDv2FeatureFlag: false,
+  /**
    * When reading OpenPGP v4 private keys (e.g. those generated in OpenPGP.js when not setting `config.v5Keys = true`)
    * which were encrypted by OpenPGP.js v5 (or older) using `config.aeadProtect = true`,
    * this option must be set, otherwise key parsing and/or key decryption will fail.

--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -173,7 +173,8 @@ export async function getPreferredCompressionAlgo(keys = [], date = new Date(), 
 export async function getPreferredCipherSuite(keys = [], date = new Date(), userIDs = [], config = defaultConfig) {
   const selfSigs = await Promise.all(keys.map((key, i) => key.getPrimarySelfSignature(date, userIDs[i], config)));
   const withAEAD = keys.length ?
-    selfSigs.every(selfSig => selfSig.features && (selfSig.features[0] & enums.features.seipdv2)) :
+    selfSigs.every(selfSig => (
+      selfSig.features && (selfSig.features[0] & enums.features.seipdv2) && !config.ignoreSEIPDv2FeatureFlag)) :
     config.aeadProtect;
 
   if (withAEAD) {

--- a/src/key/helper.js
+++ b/src/key/helper.js
@@ -173,8 +173,7 @@ export async function getPreferredCompressionAlgo(keys = [], date = new Date(), 
 export async function getPreferredCipherSuite(keys = [], date = new Date(), userIDs = [], config = defaultConfig) {
   const selfSigs = await Promise.all(keys.map((key, i) => key.getPrimarySelfSignature(date, userIDs[i], config)));
   const withAEAD = keys.length ?
-    selfSigs.every(selfSig => (
-      selfSig.features && (selfSig.features[0] & enums.features.seipdv2) && !config.ignoreSEIPDv2FeatureFlag)) :
+    !config.ignoreSEIPDv2FeatureFlag && selfSigs.every(selfSig => selfSig.features && (selfSig.features[0] & enums.features.seipdv2)) :
     config.aeadProtect;
 
   if (withAEAD) {

--- a/test/general/openpgp.js
+++ b/test/general/openpgp.js
@@ -2253,6 +2253,17 @@ k0mXubZvyl4GBg==
       expect(seipd).to.be.instanceOf(openpgp.SymEncryptedIntegrityProtectedDataPacket);
       expect(seipd.version).to.equal(2);
       expect(seipd.aeadAlgorithm).to.equal(openpgp.enums.aead.ocb);
+
+      const encryptedWithoutAEAD = await openpgp.encrypt({
+        message: await openpgp.createMessage({ text: 'test' }),
+        encryptionKeys: [v4PrivateKeyWithOCBPref, v6PrivateKeyWithOCBPref],
+        format: 'object',
+        config: { ignoreSEIPDv2FeatureFlag: true }
+      });
+
+      const seipdV1 = encryptedWithoutAEAD.packets[2];
+      expect(seipdV1).to.be.instanceOf(openpgp.SymEncryptedIntegrityProtectedDataPacket);
+      expect(seipdV1.version).to.equal(1);
     });
 
     it('should support encrypting to a key without features (missing SEIPDv1 feature)', async function () {


### PR DESCRIPTION
SEIPDv2 is a more secure and faster choice, but it is not necessarily compatible with other libs and our mobile apps.