### PR TITLE
[v6] Use noble-ed25519 instead of tweetnacl for signature verification

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "LGPL-3.0+",
       "devDependencies": {
         "@noble/curves": "^1.4.0",
+        "@noble/ed25519": "^1.7.3",
         "@noble/hashes": "^1.4.0",
         "@openpgp/asmcrypto.js": "^3.1.0",
         "@openpgp/jsdoc": "^3.6.11",
@@ -812,6 +813,18 @@
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/@noble/ed25519": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
+      "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
     },
     "node_modules/@noble/hashes": {
       "version": "1.4.0",
@@ -9049,6 +9062,12 @@
       "requires": {
         "@noble/hashes": "1.4.0"
       }
+    },
+    "@noble/ed25519": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
+      "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==",
+      "dev": true
     },
     "@noble/hashes": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   },
   "devDependencies": {
     "@noble/curves": "^1.4.0",
+    "@noble/ed25519": "^1.7.3",
     "@noble/hashes": "^1.4.0",
     "@openpgp/asmcrypto.js": "^3.1.0",
     "@openpgp/jsdoc": "^3.6.11",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -80,6 +80,13 @@ export default Object.assign([
         ignore: nodeBuiltinModules.concat(nodeDependencies)
       }),
       replace({
+        include: 'node_modules/@noble/ed25519/**',
+        // Rollup ignores the `browser: { crypto: false }` directive in package.json, since `exports` are present,
+        // hence we need to manually drop it.
+        "import * as nodeCrypto from 'crypto'": 'const nodeCrypto = null',
+        delimiters: ['', '']
+      }),
+      replace({
         'OpenPGP.js VERSION': `OpenPGP.js ${pkg.version}`,
         "import { createRequire } from 'module';": 'const createRequire = () => () => {}',
         delimiters: ['', '']
@@ -129,6 +136,13 @@ export default Object.assign([
         ignore: nodeBuiltinModules.concat(nodeDependencies)
       }),
       replace({
+        include: 'node_modules/@noble/ed25519/**',
+        // Rollup ignores the `browser: { crypto: false }` directive in package.json, since `exports` are present,
+        // hence we need to manually drop it.
+        "import * as nodeCrypto from 'crypto'": 'const nodeCrypto = null',
+        delimiters: ['', '']
+      }),
+      replace({
         'OpenPGP.js VERSION': `OpenPGP.js ${pkg.version}`,
         "import { createRequire } from 'module';": 'const createRequire = () => () => {}',
         delimiters: ['', '']
@@ -157,6 +171,13 @@ export default Object.assign([
       commonjs({
         ignore: nodeBuiltinModules.concat(nodeDependencies),
         requireReturnsDefault: 'preferred'
+      }),
+      replace({
+        include: 'node_modules/@noble/ed25519/**',
+        // Rollup ignores the `browser: { crypto: false }` directive in package.json, since `exports` are present,
+        // hence we need to manually drop it.
+        "import * as nodeCrypto from 'crypto'": 'const nodeCrypto = null',
+        delimiters: ['', '']
       }),
       replace({
         "import { createRequire } from 'module';": 'const createRequire = () => () => {}',

--- a/src/crypto/public_key/elliptic/eddsa_legacy.js
+++ b/src/crypto/public_key/elliptic/eddsa_legacy.js
@@ -21,7 +21,8 @@
  * @module crypto/public_key/elliptic/eddsa_legacy
  */
 
-import nacl from '@openpgp/tweetnacl';
+import naclEd25519 from '@openpgp/tweetnacl'; // better constant-timeness as it uses Uint8Arrays over BigInts
+import { verify as nobleEd25519Verify } from '@noble/ed25519';
 import util from '../../../util';
 import enums from '../../../enums';
 import hash from '../../hash';
@@ -46,7 +47,7 @@ export async function sign(oid, hashAlgo, message, publicKey, privateKey, hashed
     throw new Error('Hash algorithm too weak for EdDSA.');
   }
   const secretKey = util.concatUint8Array([privateKey, publicKey.subarray(1)]);
-  const signature = nacl.sign.detached(hashed, secretKey);
+  const signature = naclEd25519.sign.detached(hashed, secretKey);
   // EdDSA signature params are returned in little-endian format
   return {
     r: signature.subarray(0, 32),
@@ -71,7 +72,7 @@ export async function verify(oid, hashAlgo, { r, s }, m, publicKey, hashed) {
     throw new Error('Hash algorithm too weak for EdDSA.');
   }
   const signature = util.concatUint8Array([r, s]);
-  return nacl.sign.detached.verify(hashed, signature, publicKey.subarray(1));
+  return nobleEd25519Verify(signature, hashed, publicKey.subarray(1));
 }
 /**
  * Validate legacy EdDSA parameters
@@ -91,7 +92,7 @@ export async function validateParams(oid, Q, k) {
    * Derive public point Q' = dG from private key
    * and expect Q == Q'
    */
-  const { publicKey } = nacl.sign.keyPair.fromSeed(k);
+  const { publicKey } = naclEd25519.sign.keyPair.fromSeed(k);
   const dG = new Uint8Array([0x40, ...publicKey]); // Add public key prefix
   return util.equalsUint8Array(Q, dG);
 


### PR DESCRIPTION
Faster than tweetnacl, and no constant-timeness required.

We are not using v2 for now, despite it being smaller, because it relies on bigint literals, and it requires polyfilling the WebCrypto lib manually in Node < 19.